### PR TITLE
商品详情页尺码遮罩层禁止穿透（请使用真机测试，模拟器无效果）

### DIFF
--- a/pages/goods-details/index.wxml
+++ b/pages/goods-details/index.wxml
@@ -84,7 +84,7 @@
         <view wx:if="{{goodsDetail.basicInfo.pingtuan}}" class="join-shop-cart" bindtap="tobuy">单独购买</view>
         <view wx:if="{{goodsDetail.basicInfo.pingtuan}}" class="now-buy" bindtap="toPingtuan">发起拼团</view>
    </view>
-    <view class="show-popup" hidden="{{hideShopPopup}}" >
+    <view class="show-popup" hidden="{{hideShopPopup}}" catchtouchmove="true">
         <view class="popup-mask" bindtap="closePopupTap"></view>
         <view class="popup-contents">
              <view class="pop-goods-info">


### PR DESCRIPTION
商品详情页在弹出尺码遮罩层时，禁止穿透遮罩进行滚动，模拟器中无效果，使用真机调试即可，可解决issues #114 