### PR TITLE
修复更换头像导致头像失效的问题；增加订单数量小红点；

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ App({
       }
     })
   },
-    
+
   onShow (e) {
     this.globalData.launchOption = e
     // 保存邀请人
@@ -103,13 +103,25 @@ App({
       }
     }
     // 自动登录
-    AUTH.checkHasLogined().then(isLogined => {
+    AUTH.checkHasLogined().then(async isLogined => {
       if (!isLogined) {
         AUTH.login()
+      } else {
+        AUTH.getUserInfo().then((res) => {
+          const { userInfo } = res
+          // 更新用户信息
+          WXAPI.modifyUserInfo({
+            avatarUrl: userInfo.avatarUrl,
+            city: userInfo.city,
+            nick: userInfo.nickName,
+            province: userInfo.province,
+            token: wx.getStorageSync('token')
+          })
+        })
       }
     })
   },
-  globalData: {                
+  globalData: {
     isConnected: true
   }
 })

--- a/pages/my/index.js
+++ b/pages/my/index.js
@@ -13,10 +13,16 @@ Page({
     score:0,
     growth:0,
     score_sign_continuous:0,
-    rechargeOpen: false // 是否开启充值[预存]功能
+    rechargeOpen: false, // 是否开启充值[预存]功能
+
+    // 用户订单统计数据
+    count_id_no_confirm: 0,
+    count_id_no_pay: 0,
+    count_id_no_reputation: 0,
+    count_id_no_transfer: 0,
   },
 	onLoad() {
-	},	
+	},
   onShow() {
     const _this = this
     const order_hx_uids = wx.getStorageSync('order_hx_uids')
@@ -28,9 +34,10 @@ Page({
       this.setData({
         wxlogin: isLogined
       })
-      if (isLogined) {        
+      if (isLogined) {
         _this.getUserApiInfo();
         _this.getUserAmount();
+        _this.orderStatistics();
       }
     })
     // 获取购物车数据，显示TabBarBadge
@@ -107,6 +114,27 @@ Page({
           score: res.data.score,
           growth: res.data.growth
         });
+      }
+    })
+  },
+  handleOrderCount: function (count) {
+    return count > 99 ? '99+' : count;
+  },
+  orderStatistics: function () {
+    WXAPI.orderStatistics(wx.getStorageSync('token')).then((res) => {
+      if (res.code == 0) {
+        const {
+          count_id_no_confirm,
+          count_id_no_pay,
+          count_id_no_reputation,
+          count_id_no_transfer,
+        } = res.data || {}
+        this.setData({
+          count_id_no_confirm: this.handleOrderCount(count_id_no_confirm),
+          count_id_no_pay: this.handleOrderCount(count_id_no_pay),
+          count_id_no_reputation: this.handleOrderCount(count_id_no_reputation),
+          count_id_no_transfer: this.handleOrderCount(count_id_no_transfer),
+        })
       }
     })
   },

--- a/pages/my/index.wxml
+++ b/pages/my/index.wxml
@@ -40,18 +40,22 @@
   <view class='order-shortcut'>
     <!-- https://www.iconfont.cn/collections/detail?spm=a313x.7781069.0.da5a778a4&cid=2767 -->
     <view class='item' bindtap='goOrder' data-type="0">
+      <view wx:if="{{count_id_no_pay !== 0}}" class='dot'>{{count_id_no_pay}}</view>
       <image class="icon" src="/images/order/topay.png" background-size="cover"></image>
       <view class='text'>待付款</view>
     </view>
     <view class='item' bindtap='goOrder' data-type="1">
+      <view wx:if="{{count_id_no_transfer !== 0}}" class='dot'>{{count_id_no_transfer}}</view>
       <image class="icon" src="/images/order/fahuo.png" background-size="cover"></image>
       <view class='text'>待发货</view>
     </view>
     <view class='item' bindtap='goOrder' data-type="2">
+      <view wx:if="{{count_id_no_confirm !== 0}}" class='dot'>{{count_id_no_confirm}}</view>
       <image class="icon" src="/images/order/shouhuo.png" background-size="cover"></image>
       <view class='text'>待收货</view>
     </view>
     <view class='item' bindtap='goOrder' data-type="3">
+      <view wx:if="{{count_id_no_reputation !== 0}}" class='dot'>{{count_id_no_reputation}}</view>
       <image class="icon" src="/images/order/pj.png" background-size="cover"></image>
       <view class='text'>待评价</view>
     </view>
@@ -72,14 +76,14 @@
       <image class="next" src="/images/icon/next.png"></image>
     </view>
   </navigator>
-  <view class="line"></view> 
+  <view class="line"></view>
   <navigator url="/pages/asset/index">
     <view class="menu-item">
       <view class="l">资金明细</view>
       <image class="next" src="/images/icon/next.png"></image>
     </view>
   </navigator>
-  <view class="line"></view>  
+  <view class="line"></view>
   <!-- flex布局的新菜单 -->
   <!-- <view class="menu-item">
     <view class="l">我的订单</view>
@@ -140,7 +144,7 @@
     </view>
   </navigator>
 
-  <view class="space"></view>  
+  <view class="space"></view>
   <navigator url="/pages/select-address/index">
     <view class="menu-item">
       <view class="l">收货地址</view>
@@ -219,7 +223,7 @@
     <view class="l">绑定官网账号</view>
     <image class="next" src="/images/icon/next.png"></image>
   </view> -->
-  
+
   <view class="space"></view>
   <view class="version">EastWorld v {{version}}</view>
   <view class="space"></view>

--- a/pages/my/index.wxss
+++ b/pages/my/index.wxss
@@ -51,7 +51,7 @@ page,view,image,input {
 .version {
   width:100vw;
 	font-size: 24rpx;
-	text-align: center;  
+	text-align: center;
   padding: 32rpx;
 }
 
@@ -61,9 +61,24 @@ page,view,image,input {
   padding-bottom: 20rpx;
 }
 .order-shortcut .item {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 150rpx;
+  text-align: center;
+}
+.order-shortcut .item .dot {
+  position: absolute;
+  right: 20rpx;
+  top: -8rpx;
+  min-width: 32rpx;
+  height: 32rpx;
+  padding: 0 7rpx;
+  line-height: 32rpx;
+  font-size: 18rpx;
+  border-radius: 32rpx;
+  background: #FF4949;
+  color: #fff;
   text-align: center;
 }
 .order-shortcut .item .icon {


### PR DESCRIPTION
1、问题：修复用户更换头像（一段时间后微信的历史头像链接会失效）导致头像失效的问题，如下图。在项目中除了用户第一次注册时，其它没有任何地方更新用户信息。
解决方案：及时更新用户信息。

![3f46d077b0099ebbca28e353ee5596d0](https://user-images.githubusercontent.com/13075469/82036821-f02d7c00-96d3-11ea-97df-6be3265e0fc4.png)

2、更新：个人中心页面订单增加订单数量小红点。效果如下图。

<img width="307" alt="bb23d88db5f0e0d61dba2849450bde2b" src="https://user-images.githubusercontent.com/13075469/82036611-afcdfe00-96d3-11ea-9b00-7ce90d985a7b.png">
