### PR TITLE
修复单击“去首页看看”进不了首页的bug

### DIFF
--- a/pages/goods/his.wxml
+++ b/pages/goods/his.wxml
@@ -45,7 +45,7 @@
     <view class="empty-icon">🛍️</view>
     <view class="empty-text">暂无浏览记录</view>
     <view class="empty-tip">快去逛逛吧～</view>
-    <navigator url="/pages/index/index" class="empty-btn">去首页看看</navigator>
+    <navigator url="/pages/index/index" open-type="switchTab" class="empty-btn">去首页看看</navigator>
   </view>
 </view>
 


### PR DESCRIPTION
解决方案： 在 <navigator> 组件中添加了 open-type="switchTab" 属性，这样点击"去首页看看"按钮就能正确跳转到首页了。